### PR TITLE
Fix go-lint errors

### DIFF
--- a/cns.go
+++ b/cns.go
@@ -1,6 +1,9 @@
 package resolution
 
 import (
+	"math/big"
+	s "strings"
+
 	"github.com/DeRain/resolution-go/cns/contracts/proxyreader"
 	"github.com/DeRain/resolution-go/cns/contracts/resolver"
 	"github.com/DeRain/resolution-go/dnsrecords"
@@ -8,8 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	kns "github.com/jgimeno/go-namehash"
-	"math/big"
-	s "strings"
 )
 
 type Cns struct {
@@ -25,6 +26,7 @@ var cnsZeroAddress = common.HexToAddress("0x0")
 var cnsMainnetProxyReader = common.HexToAddress("0xa6E7cEf2EDDEA66352Fd68E5915b60BDbb7309f5")
 var cnsMainnetDefaultResolver = common.HexToAddress("0xb66DcE2DA6afAAa98F2013446dBCB0f4B0ab2842")
 
+// NewCns Creates instance of Cns with specific provider
 func NewCns(backend bind.ContractBackend) (*Cns, error) {
 	contract, err := proxyreader.NewContract(cnsMainnetProxyReader, backend)
 	if err != nil {
@@ -38,6 +40,7 @@ func NewCns(backend bind.ContractBackend) (*Cns, error) {
 	return &Cns{ProxyReader: contract, SupportedKeys: supportedKeys, ContractBackend: backend}, nil
 }
 
+// NewCnsWithDefaultBackend Creates instance of Cns with default provider
 func NewCnsWithDefaultBackend() (*Cns, error) {
 	backend, err := ethclient.Dial(cnsProvider)
 	if err != nil {
@@ -51,6 +54,7 @@ func NewCnsWithDefaultBackend() (*Cns, error) {
 	return cns, nil
 }
 
+// Data Retrieve data of domain
 func (c *Cns) Data(domainName string, keys []string) (*struct {
 	Resolver common.Address
 	Owner    common.Address
@@ -59,8 +63,8 @@ func (c *Cns) Data(domainName string, keys []string) (*struct {
 	normalizedName := NormalizeName(domainName)
 	// todo validate domain name
 	namehash := kns.NameHash(normalizedName)
-	tokenId := namehash.Big()
-	data, err := c.ProxyReader.GetData(&bind.CallOpts{Pending: false}, keys, tokenId)
+	tokenID := namehash.Big()
+	data, err := c.ProxyReader.GetData(&bind.CallOpts{Pending: false}, keys, tokenID)
 	if err != nil {
 		return nil, err
 	}
@@ -74,6 +78,7 @@ func (c *Cns) Data(domainName string, keys []string) (*struct {
 	return &data, nil
 }
 
+// Records retrieve records of domain
 func (c *Cns) Records(domainName string, keys []string) (map[string]string, error) {
 	data, err := c.Data(domainName, keys)
 	if err != nil {
@@ -86,6 +91,7 @@ func (c *Cns) Records(domainName string, keys []string) (map[string]string, erro
 	return allRecords, nil
 }
 
+// Record Retrieve single record of domain
 func (c *Cns) Record(domainName string, key string) (string, error) {
 	records, err := c.Records(domainName, []string{key})
 	if err != nil {
@@ -94,6 +100,7 @@ func (c *Cns) Record(domainName string, key string) (string, error) {
 	return records[key], nil
 }
 
+// Addr Retrieve the value of domain's currency ticker
 func (c *Cns) Addr(domainName string, ticker string) (string, error) {
 	// todo replace concat by string builder
 	key := "crypto." + s.ToUpper(ticker) + ".address"
@@ -104,6 +111,7 @@ func (c *Cns) Addr(domainName string, ticker string) (string, error) {
 	return value, nil
 }
 
+// AddrVersion Retrieve the version value of domain's currency ticker - useful for multichain currencies
 func (c *Cns) AddrVersion(domainName string, ticker string, version string) (string, error) {
 	// todo replace concat by string builder
 	key := "crypto." + s.ToUpper(ticker) + ".version." + s.ToUpper(version) + ".address"
@@ -114,6 +122,7 @@ func (c *Cns) AddrVersion(domainName string, ticker string, version string) (str
 	return value, nil
 }
 
+// Email Retrieve the email of domain
 func (c *Cns) Email(domainName string) (string, error) {
 	key := "whois.email.value"
 	value, err := c.Record(domainName, key)
@@ -124,6 +133,7 @@ func (c *Cns) Email(domainName string) (string, error) {
 	return value, nil
 }
 
+// Resolver Retrieve the resolver set for a domain
 func (c *Cns) Resolver(domainName string) (string, error) {
 	data, err := c.Data(domainName, []string{})
 	if err != nil {
@@ -133,6 +143,7 @@ func (c *Cns) Resolver(domainName string) (string, error) {
 	return data.Resolver.String(), nil
 }
 
+// Owner Retrieve the owner of a domain
 func (c *Cns) Owner(domainName string) (string, error) {
 	data, err := c.Data(domainName, []string{})
 	if err != nil {
@@ -142,6 +153,7 @@ func (c *Cns) Owner(domainName string) (string, error) {
 	return data.Owner.String(), nil
 }
 
+// IpfsHash Retrieve the ipfs hash of a domain
 func (c *Cns) IpfsHash(domainName string) (string, error) {
 	records, err := c.Records(domainName, []string{"dweb.ipfs.hash", "ipfs.html.value"})
 	if err != nil {
@@ -157,7 +169,8 @@ func (c *Cns) IpfsHash(domainName string) (string, error) {
 	return "", nil
 }
 
-func (c *Cns) HttpUrl(domainName string) (string, error) {
+// HTTPUrl Retrieve the http redirect url of a domain
+func (c *Cns) HTTPUrl(domainName string) (string, error) {
 	records, err := c.Records(domainName, []string{"browser.redirect_url", "ipfs.redirect_domain.value"})
 	if err != nil {
 		return "", err
@@ -172,6 +185,7 @@ func (c *Cns) HttpUrl(domainName string) (string, error) {
 	return "", nil
 }
 
+// AllRecords Retrieve all records of a domain
 func (c *Cns) AllRecords(domainName string) (map[string]string, error) {
 	data, err := c.Data(domainName, []string{})
 	if err != nil {
@@ -230,8 +244,9 @@ func (c *Cns) AllRecords(domainName string) (map[string]string, error) {
 	return allRecords, nil
 }
 
-func (c *Cns) Dns(domainName string, types []dnsrecords.Type) ([]dnsrecords.Record, error) {
-	keys, err := DnsTypesToCryptoRecordKeys(types)
+// DNS Retrieve the DNS records of a domain
+func (c *Cns) DNS(domainName string, types []dnsrecords.Type) ([]dnsrecords.Record, error) {
+	keys, err := DNSTypesToCryptoRecordKeys(types)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +254,7 @@ func (c *Cns) Dns(domainName string, types []dnsrecords.Type) ([]dnsrecords.Reco
 	if err != nil {
 		return nil, err
 	}
-	dnsRecords, err := CryptoRecordsToDns(records)
+	dnsRecords, err := CryptoRecordsToDNS(records)
 	if err != nil {
 		return nil, err
 	}

--- a/cns_test.go
+++ b/cns_test.go
@@ -1,11 +1,12 @@
 package resolution
 
 import (
+	"testing"
+
 	"github.com/DeRain/resolution-go/dnsrecords"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var cns, _ = NewCnsWithDefaultBackend()
@@ -191,11 +192,11 @@ func TestCnsIpfsLegacy(t *testing.T) {
 	assert.Equal(t, expectedRecord, record)
 }
 
-func TestCnsHttpUrl(t *testing.T) {
+func TestCnsHTTPUrl(t *testing.T) {
 	t.Parallel()
 	testDomain := "udtestdev-redirect.crypto"
 	expectedRecord := "https://example.com/home.html"
-	record, err := cns.HttpUrl(testDomain)
+	record, err := cns.HTTPUrl(testDomain)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedRecord, record)
 }
@@ -204,7 +205,7 @@ func TestCnsHttpUrlLegacy(t *testing.T) {
 	t.Parallel()
 	testDomain := "udtestdev-redirect-legacy.crypto"
 	expectedRecord := "https://legacy-example.com/home.html"
-	record, err := cns.HttpUrl(testDomain)
+	record, err := cns.HTTPUrl(testDomain)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedRecord, record)
 }
@@ -248,7 +249,7 @@ func TestCnsDnsA(t *testing.T) {
 		{Type: dnsrecords.A, TTL: 1800, Value: "10.0.0.1"},
 		{Type: dnsrecords.A, TTL: 1800, Value: "10.0.0.2"},
 	}
-	dnsRecords, err := cns.Dns(testDomain, []dnsrecords.Type{"A"})
+	dnsRecords, err := cns.DNS(testDomain, []dnsrecords.Type{"A"})
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, expectedRecords, dnsRecords)
 }
@@ -259,7 +260,7 @@ func TestCnsDnsCname(t *testing.T) {
 	expectedRecords := []dnsrecords.Record{
 		{Type: dnsrecords.CNAME, TTL: 1111, Value: "example.com."},
 	}
-	dnsRecords, err := cns.Dns(testDomain, []dnsrecords.Type{"CNAME"})
+	dnsRecords, err := cns.DNS(testDomain, []dnsrecords.Type{"CNAME"})
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, expectedRecords, dnsRecords)
 }
@@ -271,7 +272,7 @@ func TestCnsDnsGlobalTtl(t *testing.T) {
 		{Type: dnsrecords.A, TTL: 1000, Value: "10.0.0.1"},
 		{Type: dnsrecords.A, TTL: 1000, Value: "10.0.0.2"},
 	}
-	dnsRecords, err := cns.Dns(testDomain, []dnsrecords.Type{"A"})
+	dnsRecords, err := cns.DNS(testDomain, []dnsrecords.Type{"A"})
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, expectedRecords, dnsRecords)
 }

--- a/dnsrecords.go
+++ b/dnsrecords.go
@@ -3,12 +3,14 @@ package resolution
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/DeRain/resolution-go/dnsrecords"
 	"strconv"
 	"strings"
+
+	"github.com/DeRain/resolution-go/dnsrecords"
 )
 
-func DnsTypesToCryptoRecordKeys(types []dnsrecords.Type) ([]string, error) {
+// DNSTypesToCryptoRecordKeys Converts dns types to crypto record keys
+func DNSTypesToCryptoRecordKeys(types []dnsrecords.Type) ([]string, error) {
 	recordKeys := []string{"dns.ttl"}
 	var key strings.Builder
 	var ttlKey strings.Builder
@@ -29,7 +31,8 @@ func DnsTypesToCryptoRecordKeys(types []dnsrecords.Type) ([]string, error) {
 	return recordKeys, nil
 }
 
-func CryptoRecordsToDns(cryptoRecords map[string]string) ([]dnsrecords.Record, error) {
+// CryptoRecordsToDNS Converts crypto records dns types
+func CryptoRecordsToDNS(cryptoRecords map[string]string) ([]dnsrecords.Record, error) {
 	var globalTTL = dnsrecords.DefaultTTL
 	if cryptoRecords["dns.ttl"] != "" {
 		parsedTTL, err := strconv.ParseUint(cryptoRecords["dns.ttl"], 10, 32)
@@ -38,7 +41,7 @@ func CryptoRecordsToDns(cryptoRecords map[string]string) ([]dnsrecords.Record, e
 		}
 	}
 	var ttlKey strings.Builder
-	var parsedDnsRecords []dnsrecords.Record
+	var parsedDNSRecords []dnsrecords.Record
 	for cryptoKey, cryptoValue := range cryptoRecords {
 		if strings.Index(cryptoKey, "dns.") == 0 {
 			keyParts := strings.Split(cryptoKey, ".")
@@ -56,16 +59,16 @@ func CryptoRecordsToDns(cryptoRecords map[string]string) ([]dnsrecords.Record, e
 						recordTTL = uint32(parsedTTL)
 					}
 				}
-				var parsedDnsRecordValues []string
-				err = json.Unmarshal([]byte(cryptoValue), &parsedDnsRecordValues)
+				var parsedDNSRecordValues []string
+				err = json.Unmarshal([]byte(cryptoValue), &parsedDNSRecordValues)
 				if err == nil {
-					for _, dnsRecordValue := range parsedDnsRecordValues {
-						parsedDnsRecords = append(parsedDnsRecords, dnsrecords.Record{Type: recordType, TTL: recordTTL, Value: dnsRecordValue})
+					for _, dnsRecordValue := range parsedDNSRecordValues {
+						parsedDNSRecords = append(parsedDNSRecords, dnsrecords.Record{Type: recordType, TTL: recordTTL, Value: dnsRecordValue})
 					}
 				}
 			}
 		}
 	}
 
-	return parsedDnsRecords, nil
+	return parsedDNSRecords, nil
 }

--- a/dnsrecords_test.go
+++ b/dnsrecords_test.go
@@ -1,15 +1,16 @@
 package resolution
 
 import (
+	"testing"
+
 	"github.com/DeRain/resolution-go/dnsrecords"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestDnsTypesToRecordKeys(t *testing.T) {
 	t.Parallel()
 	expectedRecords := []string{"dns.ttl", "dns.A", "dns.A.ttl", "dns.AAAA", "dns.AAAA.ttl"}
-	records, err := DnsTypesToCryptoRecordKeys([]dnsrecords.Type{dnsrecords.A, dnsrecords.AAAA})
+	records, err := DNSTypesToCryptoRecordKeys([]dnsrecords.Type{dnsrecords.A, dnsrecords.AAAA})
 	assert.Nil(t, err)
 	assert.Equal(t, expectedRecords, records)
 }
@@ -17,7 +18,7 @@ func TestDnsTypesToRecordKeys(t *testing.T) {
 func TestEmptyDnsTypesToRecordKeys(t *testing.T) {
 	t.Parallel()
 	expectedRecords := []string{"dns.ttl"}
-	records, err := DnsTypesToCryptoRecordKeys([]dnsrecords.Type{})
+	records, err := DNSTypesToCryptoRecordKeys([]dnsrecords.Type{})
 	assert.Nil(t, err)
 	assert.Equal(t, expectedRecords, records)
 }
@@ -32,7 +33,7 @@ func TestCryptoRecordsToDns(t *testing.T) {
 		{Type: dnsrecords.TXT, TTL: 666, Value: "unstoppable"},
 		{Type: dnsrecords.TXT, TTL: 666, Value: "test"},
 	}
-	records, err := CryptoRecordsToDns(map[string]string{
+	records, err := CryptoRecordsToDNS(map[string]string{
 		"dns.A":          "[\"10.0.0.1\",\"10.0.0.2\"]",
 		"dns.AAAA":       "[\"2400:cb00:2049:1::a29f:1804\",\"2001:db8::8a2e:370:7334\"]",
 		"dns.A.ttl":      "1800",
@@ -48,7 +49,7 @@ func TestCryptoRecordsToDns(t *testing.T) {
 
 func TestCryptoRecordsToDnsInvalidKeys(t *testing.T) {
 	t.Parallel()
-	records, err := CryptoRecordsToDns(map[string]string{
+	records, err := CryptoRecordsToDNS(map[string]string{
 		"crypto.BTC.address":         "bc1q359khn0phg58xgezyqsuuaha28zkwx047c0c3y",
 		"crypto.ETH.address":         "0x8aaD44321A86b170879d7A244c1e8d360c99DdA8",
 		"gundb.public_key.value":     "pqeBHabDQdCHhbdivgNEc74QO-x8CPGXq4PKWgfIzhY.7WJR5cZFuSyh1bFwx0GWzjmrim0T5Y6Bp0SSK0im3nI",
@@ -67,7 +68,7 @@ func TestCryptoRecordsToDnsDefaultTTL(t *testing.T) {
 		{Type: dnsrecords.AAAA, TTL: dnsrecords.DefaultTTL, Value: "2400:cb00:2049:1::a29f:1804"},
 		{Type: dnsrecords.TXT, TTL: dnsrecords.DefaultTTL, Value: "test"},
 	}
-	records, err := CryptoRecordsToDns(map[string]string{
+	records, err := CryptoRecordsToDNS(map[string]string{
 		"dns.A":    "[\"10.0.0.1\"]",
 		"dns.AAAA": "[\"2400:cb00:2049:1::a29f:1804\"]",
 		"dns.TXT":  "[\"test\"]",
@@ -82,7 +83,7 @@ func TestCryptoRecordsToDnsInvalidValue(t *testing.T) {
 		{Type: dnsrecords.AAAA, TTL: 1000, Value: "2400:cb00:2049:1::a29f:1804"},
 		{Type: dnsrecords.TXT, TTL: 1000, Value: "test"},
 	}
-	records, err := CryptoRecordsToDns(map[string]string{
+	records, err := CryptoRecordsToDNS(map[string]string{
 		"dns.A":    "invalid value",
 		"dns.AAAA": "[\"2400:cb00:2049:1::a29f:1804\"]",
 		"dns.TXT":  "[\"test\"]",
@@ -98,7 +99,7 @@ func TestCryptoRecordsToDnsInvalidGlobalTTL(t *testing.T) {
 		{Type: dnsrecords.AAAA, TTL: dnsrecords.DefaultTTL, Value: "2400:cb00:2049:1::a29f:1804"},
 		{Type: dnsrecords.TXT, TTL: dnsrecords.DefaultTTL, Value: "test"},
 	}
-	records, err := CryptoRecordsToDns(map[string]string{
+	records, err := CryptoRecordsToDNS(map[string]string{
 		"dns.AAAA": "[\"2400:cb00:2049:1::a29f:1804\"]",
 		"dns.TXT":  "[\"test\"]",
 		"dns.ttl":  "invalid ttl",
@@ -113,7 +114,7 @@ func TestCryptoRecordsToDnsInvalidRecordTTL(t *testing.T) {
 		{Type: dnsrecords.AAAA, TTL: 500, Value: "2400:cb00:2049:1::a29f:1804"},
 		{Type: dnsrecords.TXT, TTL: 500, Value: "test"},
 	}
-	records, err := CryptoRecordsToDns(map[string]string{
+	records, err := CryptoRecordsToDNS(map[string]string{
 		"dns.AAAA":     "[\"2400:cb00:2049:1::a29f:1804\"]",
 		"dns.AAAA.ttl": "invalid ttl",
 		"dns.TXT":      "[\"test\"]",
@@ -126,7 +127,7 @@ func TestCryptoRecordsToDnsInvalidRecordTTL(t *testing.T) {
 
 func TestCryptoRecordsToDnsEmpty(t *testing.T) {
 	t.Parallel()
-	records, err := CryptoRecordsToDns(map[string]string{})
+	records, err := CryptoRecordsToDNS(map[string]string{})
 	assert.Nil(t, err)
 	assert.Empty(t, records)
 }

--- a/error.go
+++ b/error.go
@@ -1,9 +1,12 @@
 package resolution
 
+// DomainNotRegistered Error when domain is missing an owner
+
 type DomainNotRegistered struct {
 	DomainName string
 }
 
+// DomainNotConfigured Error when domain does not have a resolver set
 type DomainNotConfigured struct {
 	DomainName string
 }

--- a/name.go
+++ b/name.go
@@ -2,6 +2,7 @@ package resolution
 
 import s "strings"
 
+// NormalizeName Normalizes domain
 func NormalizeName(domain string) string {
 	return s.ToLower(s.TrimSpace(domain))
 }

--- a/supportedkeys.go
+++ b/supportedkeys.go
@@ -4,24 +4,26 @@ import (
 	"encoding/json"
 )
 
+// SupportedKeys struct of supported keys
 type SupportedKeys map[string]struct {
 	DeprecatedKeyName string
 	Deprecated        bool
 	ValidationRegex   string
 }
 
+// NewSupportedKeys returns SupportedKeys
 func NewSupportedKeys() (SupportedKeys, error) {
 	var keysObject struct {
 		Keys SupportedKeys
 	}
-	err := json.Unmarshal(supportedKeysJson, &keysObject)
+	err := json.Unmarshal(supportedKeysJSON, &keysObject)
 	if err != nil {
 		return nil, err
 	}
 	return keysObject.Keys, nil
 }
 
-var supportedKeysJson = []byte(`
+var supportedKeysJSON = []byte(`
 {
     "version": "1.1.0",
     "keys": {

--- a/supportedkeys_test.go
+++ b/supportedkeys_test.go
@@ -1,8 +1,9 @@
 package resolution
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewSupportedKeys(t *testing.T) {

--- a/zns_test.go
+++ b/zns_test.go
@@ -1,10 +1,11 @@
 package resolution
 
 import (
+	"testing"
+
 	"github.com/DeRain/resolution-go/dnsrecords"
 	"github.com/Zilliqa/gozilliqa-sdk/provider"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var zns = NewZnsWithDefaultProvider()
@@ -172,11 +173,11 @@ func TestZnsIpfs(t *testing.T) {
 	assert.Equal(t, expectedRecord, record)
 }
 
-func TestZnsHttpUrl(t *testing.T) {
+func TestZnsHTTPUrl(t *testing.T) {
 	t.Parallel()
 	testDomain := "ffffffff.zil"
 	expectedRecord := "https://example.com/home.html"
-	record, err := zns.HttpUrl(testDomain)
+	record, err := zns.HTTPUrl(testDomain)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedRecord, record)
 }
@@ -185,7 +186,7 @@ func TestZnsHttpUrl(t *testing.T) {
 func TestZnsDns(t *testing.T) {
 	t.Parallel()
 	testDomain := "ffffffff.zil"
-	dnsRecords, err := zns.Dns(testDomain, []dnsrecords.Type{"A"})
+	dnsRecords, err := zns.DNS(testDomain, []dnsrecords.Type{"A"})
 	assert.Nil(t, err)
 	assert.Empty(t, dnsRecords)
 }
@@ -193,7 +194,7 @@ func TestZnsDns(t *testing.T) {
 func TestZnsEmptyDns(t *testing.T) {
 	t.Parallel()
 	testDomain := "ffffffff.zil"
-	dnsRecords, err := zns.Dns(testDomain, []dnsrecords.Type{})
+	dnsRecords, err := zns.DNS(testDomain, []dnsrecords.Type{})
 	assert.Nil(t, err)
 	assert.Empty(t, dnsRecords)
 }

--- a/znsnamehash.go
+++ b/znsnamehash.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// ZnsNameHash Namehash for .zil domains
 func ZnsNameHash(domainName string) (string, error) {
 	normalizedName := NormalizeName(domainName)
 	domainNodes := strings.Split(normalizedName, ".")

--- a/znsnamehash_test.go
+++ b/znsnamehash_test.go
@@ -1,8 +1,9 @@
 package resolution
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestZnsNameHash(t *testing.T) {


### PR DESCRIPTION
Includes comments on exported methods, structs, types

Fixes capitalization