### PR TITLE
fix: zcash sapling address regex

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -163,7 +163,7 @@ var supportedKeysJSON = []byte(`
     "crypto.ZEC.address": {
       "deprecatedKeyName": "ZEC",
       "deprecated": false,
-      "validationRegex": "^z([a-zA-Z0-9]){94}$|^zs([a-zA-Z0-9]){75}$|^t([a-zA-Z0-9]){34}$"
+      "validationRegex": "^z([a-zA-Z0-9]){94}$|^zs1([a-zA-Z0-9]){75}$|^t([a-zA-Z0-9]){34}$"
     },
     "crypto.ADA.address": {
       "deprecatedKeyName": "ADA",


### PR DESCRIPTION
Fix zcash sapling address regex issue reported in https://github.com/unstoppabledomains/resolution-go/issues/20